### PR TITLE
Revert Audio, Fourier, PNG, and Visualizer CMake

### DIFF
--- a/src/Spectrogram/Audio/CMakeLists.txt
+++ b/src/Spectrogram/Audio/CMakeLists.txt
@@ -1,18 +1,5 @@
 
-# TODO: I'd really like to get both ways working!
-#find_package(Libsoundio QUIET)
-if (NOT Libsoundio_FOUND)
-
-    include(FetchContent)
-    FetchContent_Declare(
-            Libsoundio
-            GIT_REPOSITORY https://github.com/UnaNancyOwen/libsoundio.git
-            GIT_TAG 6736fa2daa4b78110a43547b556c54dc5e61e7b6 # This has a patch that adds better CMake Support
-    )
-    FetchContent_MakeAvailable(Libsoundio)
-
-endif ()
-
+find_package(Libsoundio REQUIRED)
 find_package(Boost REQUIRED)
 find_package(Threads REQUIRED)
 
@@ -23,7 +10,7 @@ target_include_directories(Audio PUBLIC
         ${CMAKE_SOURCE_DIR}/src)
 
 target_link_libraries(Audio
-        libsoundio::libsoundio
+        ${LIBSOUNDIO_LIBRARIES}
         Threads::Threads
         Boost::boost)
 

--- a/src/Spectrogram/Fourier/CMakeLists.txt
+++ b/src/Spectrogram/Fourier/CMakeLists.txt
@@ -1,22 +1,10 @@
-find_package(FFTW QUIET)
-if (NOT FFTW_FOUND)
-
-    # TODO: This isn't working yet!
-    include(FetchContent)
-    FetchContent_Declare(
-            FFTW
-            URL http://www.fftw.org/fftw-3.3.8.tar.gz
-    )
-    FetchContent_MakeAvailable(FFTW)
-
-endif ()
+find_package(FFTW REQUIRED)
 
 add_library(Fourier
         processor.h processor.cpp FrequencyDomainBuffer.cpp FrequencyDomainBuffer.h Transformer.cpp Transformer.h)
 
 target_include_directories(Fourier PUBLIC
-        ${CMAKE_SOURCE_DIR}/src
-        ${fftw_SOURCE_DIR})
+        ${CMAKE_SOURCE_DIR}/src)
 
 target_link_libraries(Fourier
                 ${FFTW_LIBRARIES})

--- a/src/Spectrogram/PNG/CMakeLists.txt
+++ b/src/Spectrogram/PNG/CMakeLists.txt
@@ -1,16 +1,6 @@
 set(CMAKE_AUTOMOC ON)
 find_package(Qt5 COMPONENTS Widgets PrintSupport REQUIRED)
-
-# TODO: I Don't love this, but it does work...
-include(FetchContent)
-FetchContent_Declare(
-        QCustomPlot
-        URL https://www.qcustomplot.com/release/2.0.1/QCustomPlot-source.tar.gz
-)
-FetchContent_MakeAvailable(QCustomPlot)
-add_library(QCustomPlot "${qcustomplot_SOURCE_DIR}/qcustomplot.h" "${qcustomplot_SOURCE_DIR}/qcustomplot.cpp")
-target_link_libraries(QCustomPlot PUBLIC
-        Qt5::Widgets)
+find_package(QCustomPlot REQUIRED)
 
 
 add_library(PNG
@@ -18,18 +8,15 @@ add_library(PNG
         Writer.cpp)
 
 target_include_directories(PNG PUBLIC
-        ${CMAKE_SOURCE_DIR}/src
-        ${qcustomplot_SOURCE_DIR})
+        ${CMAKE_SOURCE_DIR}/src)
 
 target_link_libraries(PNG
-        PUBLIC
-        QCustomPlot
-        PRIVATE
+        ${QCustomPlot_LIBRARIES}
         Qt5::Widgets
         Qt5::PrintSupport)
 
 target_compile_options(PNG PRIVATE
-        -g)
+          -g)
 #         -Werror
 #         -Wall
 #         -Wextra)

--- a/src/Spectrogram/Visualizer/CMakeLists.txt
+++ b/src/Spectrogram/Visualizer/CMakeLists.txt
@@ -1,6 +1,7 @@
-
 set(CMAKE_AUTOMOC ON)
 find_package(Qt5 COMPONENTS Widgets PrintSupport REQUIRED)
+find_package(QCustomPlot REQUIRED)
+
 
 add_library(Visualizer
         QtSpectrogram.h
@@ -9,8 +10,7 @@ add_library(Visualizer
         QtAudioSystem.h)
 
 target_link_libraries(Visualizer
-#        ${QCustomPlot_LIBRARIES}
-        QCustomPlot
+        ${QCustomPlot_LIBRARIES}
         Qt5::Widgets
         Qt5::PrintSupport
         Audio


### PR DESCRIPTION
Only reverted the CMakeLists of Audio, Fourier, PNG, and Visualizer. The Settings folder is still the same and seems to work fine.